### PR TITLE
Lps 190128 test

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java
@@ -84,7 +84,7 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 			ElementInstanceUtil.toElementInstances(elementInstancesJSON);
 
 		if (ArrayUtil.isEmpty(elementInstances)) {
-			return "{}";
+			return "[]";
 		}
 
 		for (ElementInstance elementInstance : elementInstances) {

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_2/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_2/SXPBlueprintUpgradeProcess.java
@@ -95,6 +95,12 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 	private String _upgradeElementInstancesJSON(String elementInstancesJSON)
 		throws Exception {
 
+		if (elementInstancesJSON.equals("{}") ||
+			elementInstancesJSON.equals("[]")) {
+
+			return "[]";
+		}
+
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
 			elementInstancesJSON);
 


### PR DESCRIPTION
the previous commit will prevent databases that have not yet been corrupted from being corrupted, and this commit will fix corrupted databases and return "[]" when the elementInstancesJSON variable is empty without the need to create a new JSON array